### PR TITLE
fix: oldProjects that should not be converted

### DIFF
--- a/build/raise-ivy-projects-version/raise.sh
+++ b/build/raise-ivy-projects-version/raise.sh
@@ -21,7 +21,7 @@ echo "dry run: ${dryRun}"
 
 # do not convert these projects:
 declare -A exclusions=( 
-  ["ivy-core.git"]="doc/screenshots/designer/screenshots/additionalProjects/oldVersionProject" 
+  ["core.git"]="doc/screenshots/designer/screenshots/additionalProjects/oldVersionProject" 
 )
 
 workDir=$(mktemp -d -t projectConvertXXX)


### PR DESCRIPTION
- the last converter run migrated projects that shouldn't be updated.
- the exclusion depends on the git repo name ... which was changed recently