### PR TITLE
Fix compute branch name for version 10.0.x

### DIFF
--- a/github-repo-manager/src/main/java/com/axonivy/github/GitHubIssueScanner.java
+++ b/github-repo-manager/src/main/java/com/axonivy/github/GitHubIssueScanner.java
@@ -36,7 +36,7 @@ public class GitHubIssueScanner {
     var github = GitHubProvider.get();
     var tagName = "v" + version;
     if (StringUtils.isBlank(branchName)) {
-      branchName = "release/" + StringUtils.left(version, 3);
+      branchName = "release/" + StringUtils.substringBeforeLast(version, ".");
     }
     var issues = new HashSet<String>();
     for (var repoName : GitHubRepos.repos(version)) {


### PR DESCRIPTION
Instead of using the left 3 characters use all characters before the last '.'