### PR TITLE
fix: consume bpm.exec.thirdparty from static manually managed location

### DIFF
--- a/build/raise-ivy-projects-version/raise.sh
+++ b/build/raise-ivy-projects-version/raise.sh
@@ -33,8 +33,8 @@ downloadEngine(){
   fi
   jar="*thirdparty*.jar"
   if [ -z "$(ls ${workDir}/engine/dropins/${jar})" ]; then
-    curl --output ${workDir}/engine/p2.zip https://drone.ivyteam.io/unzip/maven/prefixed/ivy-core/ch.ivyteam.ivy/ch.ivyteam.ivy.core.p2/${ivyVersion}-SNAPSHOT
-    unzip -j ${workDir}/engine/p2.zip plugins/ch.ivyteam.ivy.bpm.exec.thirdparty* -d ${workDir}/engine/dropins 
+    curl --output ${workDir}/engine/dropins/bpm.exec.thirdparty_le11.jar\
+     https://p2.ivyteam.io/thirdparty-bpm/ch.ivyteam.ivy.bpm.exec.thirdparty_le11.jar
   fi
 }
 clean(){


### PR DESCRIPTION
I've uploaded this file manually: https://p2.ivyteam.io/thirdparty-bpm/
... IMO we can delete this procedure as soon as we switch to schema based process-impl