### PR TITLE
Feature/marp 756 check for security.md code of conduct.md and licence.md

### DIFF
--- a/.github/workflows/check-missing-files.yml
+++ b/.github/workflows/check-missing-files.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
     inputs:
       dryRun:
-        description: 'Whether the build should really make a change or not'
+        description: 'Indicates whether to trigger changes to a product. By default, `dryRun` is set to `true`, meaning the action will perform a check without applying changes. When set to `false`, the action will both check for and add any missing files to the products.'
         default: 'true'
       workingOrgs:
-        description: 'Working Organizations to Scan'
+        description: 'Define organizations must be checked ex: axonivy,axonivy-market'
         default: 'axonivy,axonivy-market'
   push:
     branches: [ "master" ]
@@ -61,4 +61,4 @@ jobs:
       - name: Delete TOKEN file
         run: |
           rm token_file
-          echo "Token file deleted."
+          echo "Token file removed successfully."

--- a/.github/workflows/check-missing-files.yml
+++ b/.github/workflows/check-missing-files.yml
@@ -9,7 +9,7 @@ on:
         description: 'Indicates whether to trigger changes to a product. By default, `dryRun` is set to `true`, meaning the action will perform a check without applying changes. When set to `false`, the action will both check for and add any missing files to the products.'
         default: 'true'
       workingOrgs:
-        description: 'Define organizations must be checked ex: axonivy,axonivy-market'
+        description: 'Define organizations must be checked, example: axonivy,axonivy-market'
         default: 'axonivy,axonivy-market'
   push:
     branches: [ "master" ]

--- a/.github/workflows/check-missing-files.yml
+++ b/.github/workflows/check-missing-files.yml
@@ -7,8 +7,10 @@ on:
     inputs:
       dryRun:
         description: 'Whether the build should really make a change or not'
-        required: true
         default: 'true'
+      workingOrgs:
+        description: 'Working Organizations to Scan'
+        default: 'axonivy,axonivy-market'
   push:
     branches: [ "master" ]
 
@@ -39,10 +41,23 @@ jobs:
         id: get-file-path
         run: echo "::set-output name=filepath::$(pwd)/token_file"
 
+      - name: Set default values for dryRun and workingOrgs
+        id: set-defaults
+        run: |
+          echo "dryRun=${{ github.event.inputs.dryRun || 'true' }}" >> $GITHUB_ENV
+          echo "workingOrgs=${{ github.event.inputs.workingOrgs || 'axonivy,axonivy-market' }}" >> $GITHUB_ENV        
+
       - name: Build with Maven
         working-directory: ./github-repo-manager
-        run: mvn -f pom_check_missing_file.xml -B clean compile exec:java -DDRY_RUN="true" -"DGITHUB.TOKEN.FILE"="${{ steps.get-file-path.outputs.filepath }}" -"Dexec.mainClass"="com.axonivy.github.file.GitHubMissingFiles" -"Dexec.args"="${{ github.actor }}"
-
+        run: |
+          mvn -f pom_check_missing_file.xml -B clean compile exec:java \
+            -DDRY_RUN="${{ env.dryRun }}" \
+            -DGITHUB.TOKEN.FILE="${{ steps.get-file-path.outputs.filepath }}" \
+            -Dexec.mainClass="com.axonivy.github.file.GitHubMissingFiles" \
+            -Dexec.args="${{ github.actor }}" \
+            -DGITHUB.WORKING.ORGANIZATIONS="${{ env.workingOrgs }}"
+        continue-on-error: true
+        
       - name: Delete TOKEN file
         run: |
           rm token_file

--- a/.github/workflows/check-missing-files.yml
+++ b/.github/workflows/check-missing-files.yml
@@ -1,0 +1,49 @@
+name: Checking missing files
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Whether the build should really make a change or not'
+        required: true
+        default: 'true'
+  push:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Setup Maven
+        uses: stCarolas/setup-maven@v5
+
+      - name: Create a file with TOKEN value
+        run: |
+          echo -n "${{ secrets.TOKEN }}" > token_file
+          echo "File created at: $(pwd)/token_file"
+
+      - name: Get the file path
+        id: get-file-path
+        run: echo "::set-output name=filepath::$(pwd)/token_file"
+
+      - name: Build with Maven
+        working-directory: ./github-repo-manager
+        run: mvn -f pom_check_missing_file.xml -B clean compile exec:java -DDRY_RUN="true" -"DGITHUB.TOKEN.FILE"="${{ steps.get-file-path.outputs.filepath }}" -"Dexec.mainClass"="com.axonivy.github.file.GitHubMissingFiles" -"Dexec.args"="${{ github.actor }}"
+
+      - name: Delete TOKEN file
+        run: |
+          rm token_file
+          echo "Token file deleted."

--- a/github-repo-manager/pom_check_missing_file.xml
+++ b/github-repo-manager/pom_check_missing_file.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.axonivy.github</groupId>
+  <artifactId>github-repo-manager</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <release>17</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>github-api</artifactId>
+      <version>1.326</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.11.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.26.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/github-repo-manager/src/main/java/com/axonivy/github/file/GitHubMissingFiles.java
+++ b/github-repo-manager/src/main/java/com/axonivy/github/file/GitHubMissingFiles.java
@@ -12,7 +12,6 @@ import com.axonivy.github.file.GitHubFiles.FileMeta;
 
 public class GitHubMissingFiles {
 
-  private static final List<String> WORKING_ORGANIZATIONS = List.of("axonivy");
   private static final List<FileMeta> REQUIRED_FILES = List.of(LICENSE, SECURITY, CODE_OF_CONDUCT);
   private static final List<FileMeta> REMOVE_FILES = List.of();
 
@@ -38,7 +37,7 @@ public class GitHubMissingFiles {
   }
 
   private static List<String> getWorkingOrganizations() {
-    String inputtedValue = System.getProperty("GITHUB.WORKING.ORGANIZATIONS", String.join(",", WORKING_ORGANIZATIONS));
+    String inputtedValue = System.getProperty("GITHUB.WORKING.ORGANIZATIONS");
     return Arrays.asList(inputtedValue.split(","));
   }
 

--- a/github-repo-manager/src/main/java/com/axonivy/github/file/GitHubMissingFiles.java
+++ b/github-repo-manager/src/main/java/com/axonivy/github/file/GitHubMissingFiles.java
@@ -11,7 +11,7 @@ import com.axonivy.github.file.GitHubFiles.FileMeta;
 
 public class GitHubMissingFiles {
 
-  private static final List<String> WORKING_ORGANIZATIONS = List.of("axonivy");
+  private static final List<String> WORKING_ORGANIZATIONS = List.of("axonivy-market");
   private static final List<FileMeta> REQUIRED_FILES = List.of(LICENSE, SECURITY, CODE_OF_CONDUCT);
   private static final List<FileMeta> REMOVE_FILES = List.of();
 

--- a/github-repo-manager/src/main/java/com/axonivy/github/file/GitHubMissingFiles.java
+++ b/github-repo-manager/src/main/java/com/axonivy/github/file/GitHubMissingFiles.java
@@ -5,13 +5,14 @@ import static com.axonivy.github.file.GitHubFiles.LICENSE;
 import static com.axonivy.github.file.GitHubFiles.SECURITY;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import com.axonivy.github.file.GitHubFiles.FileMeta;
 
 public class GitHubMissingFiles {
 
-  private static final List<String> WORKING_ORGANIZATIONS = List.of("axonivy-market");
+  private static final List<String> WORKING_ORGANIZATIONS = List.of("axonivy");
   private static final List<FileMeta> REQUIRED_FILES = List.of(LICENSE, SECURITY, CODE_OF_CONDUCT);
   private static final List<FileMeta> REMOVE_FILES = List.of();
 
@@ -22,17 +23,23 @@ public class GitHubMissingFiles {
       System.out.println("running updates triggered by user "+user);
     }
     int status = 0;
+    List<String> workingOrganizations = getWorkingOrganizations();
     for (var fileMeta : REQUIRED_FILES) {
       var detector = new GitHubMissingFilesDetector(fileMeta, user);
-      var returnedStatus = detector.requireFile(WORKING_ORGANIZATIONS);
+      var returnedStatus = detector.requireFile(workingOrganizations);
       status = returnedStatus != 0 ? returnedStatus : status;
     }
     for (var fileMeta : REMOVE_FILES) {
       var detector = new GitHubFilesRemover(fileMeta, user);
-      var returnedStatus = detector.removeFile(WORKING_ORGANIZATIONS);
+      var returnedStatus = detector.removeFile(workingOrganizations);
       status = returnedStatus != 0 ? returnedStatus : status;
     }
     System.exit(status);
+  }
+
+  private static List<String> getWorkingOrganizations() {
+    String inputtedValue = System.getProperty("GITHUB.WORKING.ORGANIZATIONS", String.join(",", WORKING_ORGANIZATIONS));
+    return Arrays.asList(inputtedValue.split(","));
   }
 
 }


### PR DESCRIPTION
Hi @ivy-rew ,

Currently in the story https://1ivy.atlassian.net/browse/MARP-756, I am creating a new GitHub action runner that can run the file https://github.com/axonivy/github-repo-manager/blob/master/github-repo-manager/src/main/java/com/axonivy/github/file/GitHubMissingFiles.java 
to check for LICENSE, SECURITY, and CODE_OF_CONDUCT.

I have created a YAML file and made some edits in the GitHubMissingFiles.java class. Could you please review my PR and let me know if you have any concerns?

Here is a brief explanation of the YAML file:

- This action will run at midnight.
- We have 2 inputs (dryRun and workingOrgs)
	+ the value of dryRun will be automatically set to 'true' if it is empty
	+ The value of workingOrgs will be automatically set to 'axonivy,axonivy-market'. It means will scan 2 organizations
![image](https://github.com/user-attachments/assets/8a78642d-0c49-4b35-a100-7105fcb5afc0)

- I have created a secret variable named TOKEN, which I will input the file's path into GitHubMissingFiles.java when running the Maven command.
- After a successful run, I will delete this file.
- I have also created another POM file (github-repo-manager/pom_check_missing_file.xml) to run it because the original POM file contains internal Ivy libraries that we cannot access. 
Since the main method in GitHubMissingFiles.java does not use these libraries, I cloned a new POM file and removed them (nexus.ivyteam.io and jira-plugin). 
My Maven command will use this new POM file (pom_check_missing_file.xml).

Can you help me to review my Pr ?

Thanks.