### PR TITLE
XIVY-16359 tag and branch our dedicated 'axonivy/doc' repo

### DIFF
--- a/build/raise-deps/raise.sh
+++ b/build/raise-deps/raise.sh
@@ -40,6 +40,7 @@ source "../raiseRepo.sh"
 function raiseDepsOfOurRepos {
   repos=(
     "git@github.com:axonivy/core.git"
+    "git@github.com:axonivy/doc.git"
     "git@github.com:axonivy/rules.git"
     "git@github.com:axonivy/webeditor.git"
     "git@github.com:axonivy/process-editor-core.git"

--- a/github-repo-manager/src/main/java/com/axonivy/github/GitHubRepos.java
+++ b/github-repo-manager/src/main/java/com/axonivy/github/GitHubRepos.java
@@ -37,6 +37,7 @@ public class GitHubRepos {
           "dev-workflow-ui",
           "webeditor",
           "core",
+          "doc",
           "primefaces-themes",
           "process-editor-client",
           "process-editor-core",


### PR DESCRIPTION
handles: 
- release-branch and tag creation

I think the others do not apply:
- build-plugin-version: not referenced in the doc/pom.xml
- raise-ivy-projects-version: no ivy-projects in doc
- raise-version -> done in previous PR #229
- raise-web-tester-version: no web-tester in doc/pom.xml

Not sure:
- raise-deps: I think we have no dependencies to other ivy-artifacts? Or why do we need this for the axonivy/doc ?