### PR TITLE
Revert auto-branching of branding images

### DIFF
--- a/github-repo-manager/src/main/java/com/axonivy/github/GitHubRepos.java
+++ b/github-repo-manager/src/main/java/com/axonivy/github/GitHubRepos.java
@@ -46,7 +46,6 @@ public class GitHubRepos {
           "ui-components",
           "neo",
           "doc-images",
-          "branding-images",
           "case-map-ui",
           "thirdparty-libs",
           "swagger-ui-ivy",


### PR DESCRIPTION
Seems to be accidently introduced here:
https://github.com/axonivy/github-repo-manager/commit/ee1269f40537a1e3466e74411bfde35f10da480a#r158209701
