### PR TITLE
resilient: mute mvn stdout without logfile pollution

### DIFF
--- a/build/raise-build-plugin-version/raise.sh
+++ b/build/raise-build-plugin-version/raise.sh
@@ -46,7 +46,7 @@ source "../raiseRepo.sh"
 tmpDirectory=$workDir
 
 function updateSingleRepo {
-  .ivy/raise-build-plugin-version.sh ${releaseVersion} ${snapshotVersion} >> 'maven.log'
+  .ivy/raise-build-plugin-version.sh ${releaseVersion} ${snapshotVersion} 1>/dev/null
 }
 
 function raiseVersionOfOurRepos {


### PR DESCRIPTION
- the maven.log file, brought sub-sequent git actions to fail (no real changes, and nothing staged, ...)

see https://jenkins.ivyteam.io/view/jobs/job/github-repo-manager_raise-build-plugin-version/job/master/1164/

![no-change-fails](https://github.com/user-attachments/assets/2f7885c3-c90d-4d5e-ada8-ea832a7710f7)
