### PR TITLE
Revert "Add thirdparty-libs to raise version"

### DIFF
--- a/build/raise-version/raise.sh
+++ b/build/raise-version/raise.sh
@@ -62,7 +62,6 @@ function raiseVersionOfOurRepos {
     "git@github.com:axonivy/vscode-designer.git"
     "git@github.com:axonivy/monaco-yaml-ivy.git"
     "git@github.com:axonivy/swagger-ui-ivy.git"
-    "git@github.com:axonivy/thirdparty-libs.git"
     "git@github.com:axonivy/core.git"
     "git@github.com:axonivy/doc.git"
   )


### PR DESCRIPTION
Reverts axonivy/github-repo-manager#241
Because it does not work for all branches at the moment