### PR TITLE
expose the diff of my changes in dry-run :tulip: >> :rabbit: 

### DIFF
--- a/build/raiseRepo.sh
+++ b/build/raiseRepo.sh
@@ -65,7 +65,7 @@ function runRepoUpdate {
 
     if [ "$DRY_RUN" != false ]; then
       echo ""; echo "DRY RUN: Changes were simulated however, in the following files:"
-      git --no-pager status -s
+      showDiff
     fi
 
     echo "git: commit with message: ${commitMessage}";
@@ -120,6 +120,14 @@ function runRepoUpdate {
     echo ""; echo "--> finished pushing repo '${repo}'";
   done
   cd "${currentDir}"
+}
+
+function showDiff(){
+  git --no-pager status -s | sed 's/.* //g' | while
+  read file; do
+    git --no-pager diff HEAD "$file"
+    echo "..."
+  done
 }
 
 function ghAuth(){


### PR DESCRIPTION
show the change going to be applied in DRY_RUN, instead of just listing the change files. ... so everyone can quickly decide whether the SED run did what it should :thinking: 

sample run :rocket: : https://jenkins.ivyteam.io/view/scrum-master/job/github-repo-manager_replace/job/blame/2/console
![change-preview](https://github.com/user-attachments/assets/4bc08c6f-eb89-496e-8431-180428a68d43)
